### PR TITLE
ConstantInitializer return type

### DIFF
--- a/src/loss.cpp
+++ b/src/loss.cpp
@@ -97,7 +97,7 @@ arma::vec Loss::CalcGradient (arma::vec &true_value, arma::vec &prediction)
   return loss_obj->DefinedGradient(true_value, prediction);
 }
 
-arma::vec Loss::ConstantInitializer (arma::vec &true_value)
+double Loss::ConstantInitializer (arma::vec &true_value)
 {
   // Call ConstantInitializer of the child class:
   return loss_obj->ConstantInitializer(true_value);

--- a/src/loss.h
+++ b/src/loss.h
@@ -76,7 +76,7 @@ class Loss
 
     arma::vec CalcLoss (arma::vec &, arma::vec &);
     arma::vec CalcGradient (arma::vec &, arma::vec &);
-    arma::vec ConstantInitializer (arma::vec &);
+    double ConstantInitializer (arma::vec &);
 
     std::string GetLossType ();
 };

--- a/src/loss_wrapper.cpp
+++ b/src/loss_wrapper.cpp
@@ -95,7 +95,7 @@ class LossWrapper
       return obj.CalcGradient(true_value, response);
     }
 
-    arma::vec ConstantInitializer (arma::vec &true_value)
+    double ConstantInitializer (arma::vec &true_value)
     {
       return obj.ConstantInitializer(true_value);
     }

--- a/tutorials/loss_class.R
+++ b/tutorials/loss_class.R
@@ -68,7 +68,7 @@ initOwn = function (x)
     x   = x,
     method = "BFGS"
   )$par
-  return(rep(optimum, length(x)))
+  return(optimum)
 }
 
 # Two variables to test the functionality:


### PR DESCRIPTION
Convert the return type of ConstantInitializer from 'arma::vec' to 'double'