### PR TITLE
General updates

### DIFF
--- a/tests/testthat/test_optimizer.R
+++ b/tests/testthat/test_optimizer.R
@@ -2,7 +2,7 @@ context("The optimizer works")
 
 test_that("greedy optimizer works", {
   
-  X = as.matrix(runif(100))
+  X = as.matrix(runif(100, -4, 4))
   y.linear = as.numeric(32 * X)
   y.cubic  = as.numeric(16 * X^3)
   y.pow5   = as.numeric(8 * X^5)

--- a/tests/testthat/test_optimizer.R
+++ b/tests/testthat/test_optimizer.R
@@ -3,37 +3,37 @@ context("The optimizer works")
 test_that("greedy optimizer works", {
   
   X = as.matrix(runif(100))
-  y.linear = as.numeric(4 * X)
-  y.quadratic = as.numeric(8 * X^2)
-  y.cubic = as.numeric(16 * X^3)
+  y.linear = as.numeric(32 * X)
+  y.cubic  = as.numeric(16 * X^3)
+  y.pow5   = as.numeric(8 * X^5)
   
   # Create new linear baselearner of hp and wt:
-  linear.factory    = PolynomialFactory$new(X, "X", 1)
-  quadratic.factory = PolynomialFactory$new(X, "X", 2)
-  cubic.factory     = PolynomialFactory$new(X, "X", 3)
+  linear.factory = PolynomialFactory$new(X, "X", 1)
+  cubic.factory  = PolynomialFactory$new(X, "X", 3)
+  pow5.factory   = PolynomialFactory$new(X, "X", 5)
   
   # Create new factory list:
   factory.list = FactoryList$new()
   
   # Register factorys:
   factory.list$registerFactory(linear.factory)
-  factory.list$registerFactory(quadratic.factory)
   factory.list$registerFactory(cubic.factory)
+  factory.list$registerFactory(pow5.factory)
   
   # Optimizer:
   greedy.optimizer = GreedyOptimizer$new()
   
-  res.linear    = greedy.optimizer$testOptimizer(y.linear, factory.list)
-  res.quadratic = greedy.optimizer$testOptimizer(y.quadratic, factory.list)
-  res.cubic     = greedy.optimizer$testOptimizer(y.cubic, factory.list)
+  res.linear = greedy.optimizer$testOptimizer(y.linear, factory.list)
+  res.cubic  = greedy.optimizer$testOptimizer(y.cubic, factory.list)
+  res.pow5   = greedy.optimizer$testOptimizer(y.pow5, factory.list)
   
   # Tests:
   # ------
   expect_equal(res.linear$selected.learner, "(test run) polynomial with degree 1")
-  expect_equal(res.quadratic$selected.learner, "(test run) polynomial with degree 2")
   expect_equal(res.cubic$selected.learner, "(test run) polynomial with degree 3")
+  expect_equal(res.pow5$selected.learner, "(test run) polynomial with degree 5")
   
-  expect_equal(as.numeric(res.linear$parameter), 4)
-  expect_equal(as.numeric(res.quadratic$parameter), 8)
+  expect_equal(as.numeric(res.linear$parameter), 32)
   expect_equal(as.numeric(res.cubic$parameter), 16)
+  expect_equal(as.numeric(res.pow5$parameter), 8)
 })


### PR DESCRIPTION
One test often fails due to random drawn numbers, this is encapsulated to be more secure by choosing a higher range for the uniform distribution and higher polynomial learner to force the probability of a correct solution closer to 1.